### PR TITLE
Fix assets not loading from public folder in Vite dev server

### DIFF
--- a/packages/react-plugin-vite/src/index.ts
+++ b/packages/react-plugin-vite/src/index.ts
@@ -1,6 +1,7 @@
 import { PluginOption, UserConfig, mergeConfig } from 'vite'
 import {
   AVP,
+  DEFAULT_BASE,
   getDefineByMode,
   getDefineXrEnvBase,
   getEnv,
@@ -16,6 +17,19 @@ interface WebSpatialOptions {
   // base path
   outputDir?: string
 }
+
+function getFinalBaseVite(
+  ...args: Parameters<typeof getFinalBase>
+): ReturnType<typeof getFinalBase> {
+  const base = getFinalBase(...args)
+  /**
+   * Add missing slash to the end of the URL so that relative URLs correctly map to
+   * http://localhost:5173/webspatial/avp/image.png for Vite Dev server instead of
+   * http://localhost:5173/webspatial/image.png
+   **/
+  return base === DEFAULT_BASE ? `${base}/` : base
+}
+
 export default function (options: WebSpatialOptions = {}): PluginOption[] {
   let mode = options?.mode ?? getEnv()
   let outputDir = options?.outputDir
@@ -42,7 +56,7 @@ export default function (options: WebSpatialOptions = {}): PluginOption[] {
       apply: 'serve',
       config: userCfg => {
         const userBase = userCfg.base
-        const finalBase = getFinalBase(userBase, mode, outputDir)
+        const finalBase = getFinalBaseVite(userBase, mode, outputDir)
         console.log('🚀 ~ finalBase:', finalBase)
         const userOutDir = userCfg.build?.outDir
         const finalOutdir = getFinalOutdir(userOutDir, mode, outputDir)
@@ -75,7 +89,7 @@ export default function (options: WebSpatialOptions = {}): PluginOption[] {
         const userOutDir = config.build?.outDir
         const xrEnv = getEnv()
         const userBase = config.base
-        const finalBase = getFinalBase(userBase, mode, outputDir)
+        const finalBase = getFinalBaseVite(userBase, mode, outputDir)
         const finalOutdir = getFinalOutdir(userOutDir, xrEnv, outputDir)
 
         return {

--- a/packages/shared/src/pluginUtils.ts
+++ b/packages/shared/src/pluginUtils.ts
@@ -1,4 +1,5 @@
 const AVP = 'avp'
+const DEFAULT_BASE = '/webspatial/avp'
 function getEnv(): ModeKind {
   const env = process.env.XR_ENV
   return env === 'avp' ? 'avp' : undefined
@@ -6,12 +7,12 @@ function getEnv(): ModeKind {
 
 export type ModeKind = 'avp' | undefined
 
-export { getEnv, AVP }
+export { getEnv, AVP, DEFAULT_BASE }
 
 export function getFinalBase(
   userBase: string | undefined,
   mode: ModeKind,
-  pluginOutputDir: string = '/webspatial/avp',
+  pluginOutputDir: string = DEFAULT_BASE,
 ) {
   if (mode === 'avp') {
     if (userBase !== undefined) {


### PR DESCRIPTION
When assets are referenced using relative URL (i.e. ./image.png) then this will fail when running Vite dev server because when using http://localhost:5173/webspatial/avp the relative URL converts to http://localhost:5173/webspatial/image.png. If the missing slash is added to the end of the URL then relative URLs correctly map to http://localhost:5173/webspatial/avp/image.png