### PR TITLE
Forgot to release shared library which is breaking vite-plugin

### DIFF
--- a/.changeset/sixty-moments-beg.md
+++ b/.changeset/sixty-moments-beg.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/shared': minor
+---
+
+Export DEFAULT_BASE from pluginUtils.ts


### PR DESCRIPTION
Latest version of @webspatial/vite-plugin (0.2.0) depends on @webspatial/shared which was not released causing clients to break. 