### PR TITLE
Optimize Git pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,21 +18,11 @@
     "changeset:pre-exit": "changeset pre exit alpha"
   },
   "simple-git-hooks": {
-    "pre-commit": "pnpm lint-staged && pnpm test"
+    "pre-commit": "pnpm lint-staged"
   },
   "lint-staged": {
-    "*.{js,json}": [
+    "*.{js,json,ts}": [
       "prettier --write"
-    ],
-    "*.ts?(x)": [
-      "prettier --write"
-    ],
-    "*.swift": [
-      "swiftformat"
-    ],
-    "*": [
-      "node -e \"const fs = require('fs'); process.argv.slice(1).forEach(file => { if (fs.existsSync(file)) { const size = fs.statSync(file).size; if (size >= 1048576) { console.error(`Error: ${file} is 1MB or larger`); process.exit(1); }}})\"",
-      "node -e \"const fs=require('fs'),f=process.argv[1],c=fs.readFileSync(f,'utf8').split('\\n').filter(l=>/[\\u4E00-\\u9FFF]/.test(l)); if(c.length) { console.error('Non english characters detected:\\n' + c.join('\\n')); process.exit(1); }\""
     ]
   },
   "repository": {


### PR DESCRIPTION
1. Don't run tests in Git pre-commit hook. Instead tests will be run as part of the pull request. As tests get larger they will block developers from committing code locally.
2. There should be no TSX files in this repository.
3. There should be no Swift files in this repository.
4. Large files or filenames with special characters can be manually reviewed