### PR TITLE
fix: types for vite-plugin

### DIFF
--- a/.changeset/thirty-trains-show.md
+++ b/.changeset/thirty-trains-show.md
@@ -1,0 +1,5 @@
+---
+'@webspatial/vite-plugin': patch
+---
+
+Fix type error for vite-plugin

--- a/packages/react-plugin-vite/src/index.test.ts
+++ b/packages/react-plugin-vite/src/index.test.ts
@@ -1,4 +1,5 @@
 import plugin from './index'
+import { defineConfig } from 'vite'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { DEFAULT_BASE, AVP } from '@webspatial/shared'
 
@@ -102,5 +103,9 @@ describe('@webspatial/vite-plugin default export', () => {
     )
     expect(cfg.base).toBe('/x')
     expect(cfg.resolve.alias[0].replacement).toBe('@webspatial/react-sdk/web')
+  })
+
+  it('plugin interface satisfies Vite', () => {
+    defineConfig({ plugins: [plugin()] })
   })
 })

--- a/packages/react-plugin-vite/src/index.ts
+++ b/packages/react-plugin-vite/src/index.ts
@@ -1,4 +1,4 @@
-import { ConfigEnv, UserConfig, mergeConfig } from 'vite'
+import { ConfigEnv, UserConfig, mergeConfig, Plugin } from 'vite'
 import {
   AVP,
   DEFAULT_BASE,
@@ -110,5 +110,5 @@ export default function (options: WebSpatialOptions = {}) {
         }
       },
     },
-  ] as const
+  ] as const satisfies Plugin[]
 }


### PR DESCRIPTION
Fix type error "Plugin return type is 'readonly' and cannot be assigned to the mutable type 'PluginOption[]"